### PR TITLE
Fix typo, error on case sensitive file system

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const mix = require('laravel-mix');
-const Component = require('laravel-mix/src/components/Browsersync');
+const Component = require('laravel-mix/src/components/BrowserSync');
 
 class BrowsersyncMulti extends Component {
   register(userConfig) {


### PR DESCRIPTION
Hello...

Al least on  macOS with APFS and case sensitive file system trows an error:

`[webpack-cli] Error: Cannot find module 'laravel-mix/src/components/Browsersync'`

This commit fix that.
Thanks!